### PR TITLE
Fix typos in log messages

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -171,7 +171,7 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
     Project newProject = builder.createProject(name, projectFilePath);
     if (newProject == null) {
-      LOG.error("Failed to Bazel create project");
+      LOG.error("Failed to create Bazel project");
       return null;
     }
 

--- a/base/src/com/google/idea/blaze/base/qsync/cache/ArtifactTrackerImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/cache/ArtifactTrackerImpl.java
@@ -667,7 +667,7 @@ public class ArtifactTrackerImpl implements ArtifactTracker {
           .filter(path -> !Files.isDirectory(path) && path.endsWith(".jar"))
           .collect(Collectors.reducing(0, e -> 1, Integer::sum));
     } catch (IOException e) {
-      logger.warn("Faled to read jar cache directory " + jarCacheDirectory);
+      logger.warn("Failed to read jar cache directory " + jarCacheDirectory);
       throw new UncheckedIOException(e);
     }
   }


### PR DESCRIPTION
## Summary
- fix typo in jar cache warning message
- fix grammar in auto-import failure log

## Testing
- `bazel --batch --nohome_rc --nosystem_rc test //base:unit_tests --test_output=errors --jobs=1` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883195608f48325929accf53d680496